### PR TITLE
Create routes for OwnerService

### DIFF
--- a/src/main/resources/db/migration/create_pet_clinic.sql
+++ b/src/main/resources/db/migration/create_pet_clinic.sql
@@ -4,13 +4,7 @@ CREATE TABLE IF NOT EXISTS owner (
     id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
     first_name text NOT NULL,
     last_name text NOT NULL,
+    address text NOT NULL,
     phone_number text NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS address (
-    owner_id uuid NOT NULL REFERENCES owner(id) ON DELETE CASCADE,
-    street text NOT NULL,
-    city text NOT NULL,
-    state text NOT NULL,
-    zip_code text NOT NULL
-);

--- a/src/main/scala/petclinic/ClinicServer.scala
+++ b/src/main/scala/petclinic/ClinicServer.scala
@@ -1,0 +1,96 @@
+package petclinic
+
+import petclinic.models.{Address, Owner, OwnerId}
+import zhttp.http._
+import zhttp.service.Server
+import zio.ZIOAppDefault
+import petclinic.services._
+import zio.json._
+import zio._
+
+object ClinicServer extends ZIOAppDefault {
+
+  final case class CreateOwner(firstName: String, lastName: String, address: String, phone: String)
+
+  object CreateOwner {
+
+    implicit val codec: JsonCodec[CreateOwner] = DeriveJsonCodec.gen[CreateOwner]
+
+  }
+
+  final case class UpdateOwner(
+      id: OwnerId,
+      firstName: Option[String],
+      lastName: Option[String],
+      address: Option[String],
+      phone: Option[String]
+  )
+
+  object UpdateOwner {
+
+    implicit val codec: JsonCodec[UpdateOwner] = DeriveJsonCodec.gen[UpdateOwner]
+
+  }
+
+  sealed trait AppError extends Throwable
+
+  object AppError {
+
+    case object MissingBodyError extends AppError
+
+    case class JsonDecodingError(message: String) extends AppError
+
+  }
+
+  val ownerRoutes: Http[OwnerService, Throwable, Request, Response] =
+    Http.collectZIO[Request] {
+
+      // get one owner
+      case Method.GET -> !! / "owners" / id =>
+        for {
+          id    <- OwnerId.fromString(id).orElseFail(AppError.JsonDecodingError("Invalid owner id"))
+          owner <- OwnerService.get(id)
+        } yield Response.json(owner.toJson)
+
+      // get all owners
+      case Method.GET -> !! / "owners" =>
+        OwnerService.getAll.map { owners =>
+          Response.json(owners.toJson)
+        }
+
+      // create owner
+      case req @ Method.POST -> !! / "owners" =>
+        for {
+          body        <- req.bodyAsString.orElseFail(AppError.MissingBodyError)
+          createOwner <- ZIO.from(body.fromJson[CreateOwner]).mapError(AppError.JsonDecodingError)
+          owner <-
+            OwnerService.create(createOwner.firstName, createOwner.lastName, createOwner.address, createOwner.phone)
+        } yield Response.json(owner.toJson)
+
+      // update owner
+      case req @ Method.POST -> !! / "owners" =>
+        for {
+          body        <- req.bodyAsString.orElseFail(AppError.MissingBodyError)
+          updateOwner <- ZIO.from(body.fromJson[UpdateOwner]).mapError(AppError.JsonDecodingError)
+          _ <- OwnerService.update(
+                 updateOwner.id,
+                 updateOwner.firstName,
+                 updateOwner.lastName,
+                 updateOwner.address,
+                 updateOwner.phone
+               )
+        } yield Response.ok
+
+      // delete owner
+      case req @ Method.DELETE -> !! / "owners" / id =>
+        for {
+          id    <- OwnerId.fromString(id).orElseFail(AppError.JsonDecodingError("Invalid owner id"))
+          owner <- OwnerService.delete(id)
+        } yield Response.ok
+    }
+
+  override val run: ZIO[Any, Throwable, Nothing] =
+    Server
+      .start(8080, ownerRoutes)
+      .provide(Random.live, QuillContext.dataSourceLayer, OwnerServiceLive.layer)
+}

--- a/src/main/scala/petclinic/models/Owner.scala
+++ b/src/main/scala/petclinic/models/Owner.scala
@@ -1,22 +1,32 @@
 package petclinic.models
 
 import zio._
+import zio.json._
+
 import java.util.UUID
 
 // wraps UUID as a specific OwnerId so that we cannot use an incorrect UUID
 final case class OwnerId(id: UUID) extends AnyVal
 
 object OwnerId {
+
+  def fromString(id: String): Task[OwnerId] =
+    ZIO.attempt {
+      OwnerId(UUID.fromString(id))
+    }
+
   def random: ZIO[Random, Nothing, OwnerId] = Random.nextUUID.map(OwnerId(_))
+
+  implicit val codec: JsonCodec[OwnerId] = JsonCodec[UUID].transform(OwnerId(_), _.id)
 }
 
-// extracts address to reduce the number of fields in owner
-final case class Address(ownerId: OwnerId, street: String, city: String, state: String, zip: String)
-
 // represents an owner of a pet
-final case class Owner(id: OwnerId, firstName: String, lastName: String, phone: String)
+final case class Owner(id: OwnerId, firstName: String, lastName: String, address: String, phone: String)
 
 object Owner {
-  def apply(firstName: String, lastName: String, phone: String): ZIO[Random, Nothing, Owner] =
-    OwnerId.random.map(id => Owner(id, firstName, lastName, phone))
+
+  def apply(firstName: String, lastName: String, address: String, phone: String): ZIO[Random, Nothing, Owner] =
+    OwnerId.random.map(Owner(_, firstName, lastName, address, phone))
+
+  implicit val codec: JsonCodec[Owner] = DeriveJsonCodec.gen[Owner]
 }

--- a/src/main/scala/petclinic/models/Pet.scala
+++ b/src/main/scala/petclinic/models/Pet.scala
@@ -1,0 +1,3 @@
+package petclinic.models
+
+case class Pet()

--- a/src/main/scala/petclinic/services/PetService.scala
+++ b/src/main/scala/petclinic/services/PetService.scala
@@ -1,0 +1,3 @@
+package petclinic.services
+
+trait PetService {}


### PR DESCRIPTION
I also removed the Address case class from the Owner data model and adjusted the Owner to take the address as a String instead. This change is also reflected in the removal of the Sql migration for Address. 

The decision to collapse Address was made upon realizing that in trying to minimize the fields on Owner, I significantly complicated the create and update methods in a way that didn't seem like a worthy trade-off.

Resolves #4 