### PR TITLE
Create AppointmentService tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val zioJsonVersion           = "0.3.0-RC3"
 val zioHttpVersion           = "2.0.0-RC4"
 val zioQuillVersion          = "3.17.0-RC2"
 val postgresVersion          = "42.3.3"
+val flywayVersion            = "8.5.10"
 val zioTestContainersVersion = "0.4.1"
 
 lazy val root = (project in file("."))
@@ -22,9 +23,9 @@ lazy val root = (project in file("."))
       "io.d11"                %% "zhttp-test"                        % zioHttpVersion % Test,
       "io.getquill"           %% "quill-jdbc-zio"                    % zioQuillVersion,
       "org.postgresql"         % "postgresql"                        % postgresVersion,
+      "org.flywaydb"           % "flyway-core"                       % flywayVersion,
       "io.github.scottweaver" %% "zio-2-0-testcontainers-postgresql" % zioTestContainersVersion,
-      "io.github.scottweaver" %% "zio-2-0-db-migration-aspect"       % zioTestContainersVersion,
-      "org.flywaydb"           % "flyway-core"                       % "8.5.10"
+      "io.github.scottweaver" %% "zio-2-0-db-migration-aspect"       % zioTestContainersVersion
     ),
     Test / fork := true,
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")

--- a/src/main/resources/db/migration/V1__create_pet_clinic.sql
+++ b/src/main/resources/db/migration/V1__create_pet_clinic.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS owner (
     first_name text NOT NULL,
     last_name text NOT NULL,
     address text NOT NULL,
-    phone_number text NOT NULL
+    phone text NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS pet (

--- a/src/main/resources/db/migration/V1__create_pet_clinic.sql
+++ b/src/main/resources/db/migration/V1__create_pet_clinic.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS vet
  CREATE TABLE IF NOT EXISTS appointment
  (
      id          uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-     date        date NOT NULL,
+     date        timestamp NOT NULL,
      description text NOT NULL,
      vet_id      uuid NOT NULL REFERENCES vet (id) ON DELETE CASCADE,
      pet_id      uuid NOT NULL REFERENCES pet (id) ON DELETE CASCADE

--- a/src/main/scala/petclinic/QuillContext.scala
+++ b/src/main/scala/petclinic/QuillContext.scala
@@ -7,8 +7,6 @@ import zio.ZLayer
 import javax.sql.DataSource
 
 object QuillContext extends PostgresZioJdbcContext(SnakeCase) {
-  val dataSourceLayer: ZLayer[Any, Throwable, DataSource] =
-    DataSourceLayer.fromPrefix("database")
+  val dataSourceLayer: ZLayer[Any, Nothing, DataSource] =
+    DataSourceLayer.fromPrefix("database").orDie
 }
-
-

--- a/src/main/scala/petclinic/models/Pet.scala
+++ b/src/main/scala/petclinic/models/Pet.scala
@@ -41,6 +41,10 @@ object Species {
     override def name: String = "Reptile"
   }
 
+  case object Suidae extends Species {
+    override def name: String = "Suidae"
+  }
+
   implicit val encodeSpecies: MappedEncoding[Species, String] = MappedEncoding[Species, String](_.toString)
   implicit val decodeSpecies: MappedEncoding[String, Species] = MappedEncoding[String, Species](Species.fromString)
 
@@ -49,6 +53,7 @@ object Species {
     case "Canine"  => Canine
     case "Avia"    => Avia
     case "Reptile" => Reptile
+    case "Suidae"  => Suidae
   }
 
   implicit val codec: JsonCodec[Species] = DeriveJsonCodec.gen[Species]

--- a/src/main/scala/petclinic/server/routes/AppointmentRoutes.scala
+++ b/src/main/scala/petclinic/server/routes/AppointmentRoutes.scala
@@ -8,7 +8,7 @@ import zio.json._
 
 object AppointmentRoutes {
 
-  final case class CreateAppointment(petId: PetId, date: java.time.LocalDateTime, description: String, vetId: VetId)
+  final case class CreateAppointment(petId: PetId, date: java.time.LocalDateTime, description: String)
 
   object CreateAppointment {
 
@@ -42,7 +42,7 @@ object AppointmentRoutes {
         for {
           body       <- req.bodyAsString.orElseFail(AppError.MissingBodyError)
           createAppt <- ZIO.from(body.fromJson[CreateAppointment]).mapError(AppError.JsonDecodingError)
-          appt       <- AppointmentService.create(createAppt.petId, createAppt.date, createAppt.description, createAppt.vetId)
+          appt       <- AppointmentService.create(createAppt.petId, createAppt.date, createAppt.description)
         } yield Response.json(appt.toJson)
 
       case req @ Method.POST -> !! / "appt" =>

--- a/src/main/scala/petclinic/services/VetService.scala
+++ b/src/main/scala/petclinic/services/VetService.scala
@@ -1,0 +1,31 @@
+package petclinic.services
+
+import petclinic.models.Vet
+import zio.{Function1ToLayerOps, Task, URLayer, ZIO}
+
+import javax.sql.DataSource
+import petclinic.QuillContext
+
+trait VetService {
+  def getAll: Task[List[Vet]]
+}
+
+object VetService {
+  def getAll: ZIO[VetService, Throwable, List[Vet]] =
+    ZIO.serviceWithZIO[VetService](_.getAll)
+}
+
+final case class VetServiceLive(dataSource: DataSource) extends VetService {
+
+  import QuillContext._
+
+  override def getAll: Task[List[Vet]] =
+    run(query[Vet])
+      .provideService(dataSource)
+      .map(_.toList)
+}
+
+object VetServiceLive {
+  val layer: URLayer[DataSource, VetService] =
+    (VetServiceLive.apply _).toLayer[VetService]
+}

--- a/src/test/scala/petclinic/services/AppointmentServiceSpec.scala
+++ b/src/test/scala/petclinic/services/AppointmentServiceSpec.scala
@@ -16,7 +16,7 @@ object AppointmentServiceSpec extends DefaultRunnableSpec {
           for {
             owner <- OwnerService.create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
             pet <-
-              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.fromString("Canine"), owner.id)
+              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.Canine, owner.id)
             appointment <- AppointmentService.create(
                              pet.id,
                              LocalDateTime.of(2022, 6, 12, 13, 0),
@@ -29,7 +29,7 @@ object AppointmentServiceSpec extends DefaultRunnableSpec {
           for {
             owner <- OwnerService.create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
             pet <-
-              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.fromString("Feline"), owner.id)
+              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.Feline, owner.id)
             appointment1 <-
               AppointmentService.create(pet.id, LocalDateTime.of(2022, 7, 1, 9, 0), "Lasagna allergy test")
             appointment2 <-
@@ -44,7 +44,7 @@ object AppointmentServiceSpec extends DefaultRunnableSpec {
             owner <-
               OwnerService.create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
             pet <-
-              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.fromString("Canine"), owner.id)
+              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.Canine, owner.id)
             appointment <-
               AppointmentService.create(
                 pet.id,
@@ -59,7 +59,7 @@ object AppointmentServiceSpec extends DefaultRunnableSpec {
           for {
             owner <- OwnerService.create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
             pet <-
-              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), owner.id)
+              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.Canine, owner.id)
             appointment1 <-
               AppointmentService.create(pet.id, LocalDateTime.of(2022, 5, 22, 9, 0), "Immunization")
             appointment2 <-
@@ -80,7 +80,7 @@ object AppointmentServiceSpec extends DefaultRunnableSpec {
             owner <-
               OwnerService.create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
             pet <-
-              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.fromString("Avia"), owner.id)
+              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.Avia, owner.id)
             appointment <-
               AppointmentService.create(
                 pet.id,

--- a/src/test/scala/petclinic/services/AppointmentServiceSpec.scala
+++ b/src/test/scala/petclinic/services/AppointmentServiceSpec.scala
@@ -1,0 +1,106 @@
+package petclinic.services
+
+import io.github.scottweaver.zio.aspect.DbMigrationAspect
+import io.github.scottweaver.zio.testcontainers.postgres.ZPostgreSQLContainer
+import petclinic.models.Species
+import zio.test._
+
+import java.time.{LocalDate, LocalDateTime}
+
+object AppointmentServiceSpec extends DefaultRunnableSpec {
+
+  override def spec: Spec[TestEnvironment, TestFailure[Throwable], TestSuccess] = {
+    suite("AppointmentService")(
+      suite("added appointments exist in db")(
+        test("returns true confirming existence of added appointment") {
+          for {
+            owner <- OwnerService.create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
+            pet <-
+              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.fromString("Canine"), owner.id)
+            appointment <- AppointmentService.create(
+                             pet.id,
+                             LocalDateTime.of(2022, 6, 12, 13, 0),
+                             "Get updated body measurements"
+                           )
+            getAppointment <- AppointmentService.get(appointment.id)
+          } yield assertTrue(getAppointment.get == appointment)
+        },
+        test("returns true confirming existence of many added appointments") {
+          for {
+            owner <- OwnerService.create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
+            pet <-
+              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.fromString("Feline"), owner.id)
+            appointment1 <-
+              AppointmentService.create(pet.id, LocalDateTime.of(2022, 7, 1, 9, 0), "Lasagna allergy test")
+            appointment2 <-
+              AppointmentService.create(pet.id, LocalDateTime.of(2022, 7, 11, 10, 0), "Monday allergy test")
+            appointments <- AppointmentService.getAll
+          } yield assertTrue(appointments.contains(appointment1) && appointments.contains(appointment2))
+        }
+      ),
+      suite("deleted appointments do not exist in db")(
+        test("returns true confirming non-existence of deleted appointment") {
+          for {
+            owner <-
+              OwnerService.create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
+            pet <-
+              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.fromString("Canine"), owner.id)
+            appointment <-
+              AppointmentService.create(
+                pet.id,
+                LocalDateTime.of(2022, 8, 23, 11, 0),
+                "Have scent detection measured"
+              )
+            _              <- AppointmentService.delete(appointment.id)
+            getAppointment <- AppointmentService.get(appointment.id)
+          } yield assertTrue(getAppointment.isEmpty)
+        },
+        test("returns true confirming the non-existence of many deleted appointments") {
+          for {
+            owner <- OwnerService.create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
+            pet <-
+              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), owner.id)
+            appointment1 <-
+              AppointmentService.create(pet.id, LocalDateTime.of(2022, 5, 22, 9, 0), "Immunization")
+            appointment2 <-
+              AppointmentService.create(pet.id, LocalDateTime.of(2022, 5, 23, 9, 0), "Immunization")
+            appointment3 <-
+              AppointmentService.create(pet.id, LocalDateTime.of(2022, 5, 24, 9, 0), "Immunization")
+            _               <- AppointmentService.delete(appointment1.id)
+            _               <- AppointmentService.delete(appointment2.id)
+            getAppointment1 <- AppointmentService.get(appointment1.id)
+            getAppointment2 <- AppointmentService.get(appointment2.id)
+            getAppointment3 <- AppointmentService.get(appointment3.id)
+          } yield assertTrue(getAppointment1.isEmpty && getAppointment2.isEmpty && getAppointment3.isDefined)
+        }
+      ),
+      suite("updated appointments contain accurate information")(
+        test("returns true confirming updated appointment information") {
+          for {
+            owner <-
+              OwnerService.create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
+            pet <-
+              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.fromString("Avia"), owner.id)
+            appointment <-
+              AppointmentService.create(
+                pet.id,
+                LocalDateTime.of(2022, 7, 27, 14, 0),
+                "Broken wing"
+              )
+            _              <- AppointmentService.update(appointment.id, None, Some("Two broken wings"))
+            getAppointment <- AppointmentService.get(appointment.id)
+          } yield assertTrue(getAppointment.get.description == "Two broken wings")
+        }
+      )
+    ) @@ DbMigrationAspect.migrate()()
+  }.provideCustomShared(
+    PetServiceLive.layer,
+    OwnerServiceLive.layer,
+    ZPostgreSQLContainer.Settings.default,
+    ZPostgreSQLContainer.live,
+    AppointmentServiceLive.layer,
+    VetServiceLive.layer,
+    TestContainerLayers.dataSourceLayer
+  )
+
+}

--- a/src/test/scala/petclinic/services/OwnerServiceSpec.scala
+++ b/src/test/scala/petclinic/services/OwnerServiceSpec.scala
@@ -1,0 +1,71 @@
+package petclinic.services
+
+import io.github.scottweaver.zio.aspect.DbMigrationAspect
+import io.github.scottweaver.zio.testcontainers.postgres.ZPostgreSQLContainer
+import zio.test._
+
+object OwnerServiceSpec extends DefaultRunnableSpec {
+
+  import OwnerService._
+
+  override def spec: Spec[TestEnvironment, TestFailure[Throwable], TestSuccess] = {
+
+    suite("added owners exist in db")(
+      test("returns true confirming existence of added owner") {
+        for {
+          createOwner <- create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
+          owner       <- get(createOwner.id)
+        } yield assertTrue(owner.get == createOwner)
+      },
+      test("returns true confirming existence of many added owners") {
+        for {
+          createOwner1 <- create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
+          createOwner2 <- create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
+          owners       <- getAll
+        } yield assertTrue(owners.contains(createOwner1) && owners.contains(createOwner2) && owners.size == 2)
+      }
+    ) @@ DbMigrationAspect.migrate()()
+
+    suite("deleted owners do not exist in db")(
+      test("returns false confirming non-existence of deleted owner") {
+        for {
+          createOwner <-
+            create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
+          _     <- delete(createOwner.id)
+          owner <- get(createOwner.id)
+        } yield assertTrue(owner.isEmpty)
+      },
+      test("returns false confirming non-existence of many deleted owners") {
+        for {
+          createOwner1 <- create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
+          createOwner2 <- create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
+          createOwner3 <- create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
+          _            <- delete(createOwner1.id)
+          _            <- delete(createOwner2.id)
+          owner1       <- get(createOwner1.id)
+          owner2       <- get(createOwner2.id)
+          owner3       <- get(createOwner3.id)
+        } yield assertTrue(owner1.isEmpty && owner2.isEmpty && owner3.isDefined)
+      }
+    ) @@ DbMigrationAspect.migrate()()
+
+    suite("updated owners contain accurate information")(
+      test("returns true confirming updated owner information") {
+        for {
+          createOwner <- create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
+          _           <- update(createOwner.id, None, None, Some("12 Grimmauld Place, London, England, UK"), None)
+          owner       <- get(createOwner.id)
+        } yield assertTrue(
+          owner.get.firstName == "Harry" && owner.get.address == "12 Grimmauld Place, London, England, UK" && owner.get.address != "4 Privet Drive, Little Whinging, Surrey, UK"
+        )
+      }
+    ) @@ DbMigrationAspect.migrate()()
+
+  }.provideCustomShared(
+    OwnerServiceLive.layer,
+    ZPostgreSQLContainer.Settings.default,
+    ZPostgreSQLContainer.live,
+    TestContainerLayers.dataSourceLayer
+  )
+
+}

--- a/src/test/scala/petclinic/services/OwnerServiceSpec.scala
+++ b/src/test/scala/petclinic/services/OwnerServiceSpec.scala
@@ -9,63 +9,61 @@ object OwnerServiceSpec extends DefaultRunnableSpec {
   import OwnerService._
 
   override def spec: Spec[TestEnvironment, TestFailure[Throwable], TestSuccess] = {
-
-    suite("added owners exist in db")(
-      test("returns true confirming existence of added owner") {
-        for {
-          createOwner <- create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
-          owner       <- get(createOwner.id)
-        } yield assertTrue(owner.get == createOwner)
-      },
-      test("returns true confirming existence of many added owners") {
-        for {
-          createOwner1 <- create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
-          createOwner2 <- create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
-          owners       <- getAll
-        } yield assertTrue(owners.contains(createOwner1) && owners.contains(createOwner2) && owners.size == 2)
-      }
+    suite("OwnerService")(
+      suite("added owners exist in db")(
+        test("returns true confirming existence of added owner") {
+          for {
+            createOwner <- create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
+            owner       <- get(createOwner.id)
+          } yield assertTrue(owner.get == createOwner)
+        },
+        test("returns true confirming existence of many added owners") {
+          for {
+            createOwner1 <- create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
+            createOwner2 <- create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
+            owners       <- getAll
+          } yield assertTrue(owners.contains(createOwner1) && owners.contains(createOwner2) && owners.size == 2)
+        }
+      ),
+      suite("deleted owners do not exist in db")(
+        test("returns false confirming non-existence of deleted owner") {
+          for {
+            createOwner <-
+              create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
+            _     <- delete(createOwner.id)
+            owner <- get(createOwner.id)
+          } yield assertTrue(owner.isEmpty)
+        },
+        test("returns false confirming non-existence of many deleted owners") {
+          for {
+            createOwner1 <- create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
+            createOwner2 <- create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
+            createOwner3 <- create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
+            _            <- delete(createOwner1.id)
+            _            <- delete(createOwner2.id)
+            owner1       <- get(createOwner1.id)
+            owner2       <- get(createOwner2.id)
+            owner3       <- get(createOwner3.id)
+          } yield assertTrue(owner1.isEmpty && owner2.isEmpty && owner3.isDefined)
+        }
+      ),
+      suite("updated owners contain accurate information")(
+        test("returns true confirming updated owner information") {
+          for {
+            createOwner <- create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
+            _           <- update(createOwner.id, None, None, Some("12 Grimmauld Place, London, England, UK"), None)
+            owner       <- get(createOwner.id)
+          } yield assertTrue(
+            owner.get.firstName == "Harry" && owner.get.address == "12 Grimmauld Place, London, England, UK" && owner.get.address != "4 Privet Drive, Little Whinging, Surrey, UK"
+          )
+        }
+      )
     ) @@ DbMigrationAspect.migrate()()
-
-    suite("deleted owners do not exist in db")(
-      test("returns false confirming non-existence of deleted owner") {
-        for {
-          createOwner <-
-            create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
-          _     <- delete(createOwner.id)
-          owner <- get(createOwner.id)
-        } yield assertTrue(owner.isEmpty)
-      },
-      test("returns false confirming non-existence of many deleted owners") {
-        for {
-          createOwner1 <- create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
-          createOwner2 <- create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
-          createOwner3 <- create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
-          _            <- delete(createOwner1.id)
-          _            <- delete(createOwner2.id)
-          owner1       <- get(createOwner1.id)
-          owner2       <- get(createOwner2.id)
-          owner3       <- get(createOwner3.id)
-        } yield assertTrue(owner1.isEmpty && owner2.isEmpty && owner3.isDefined)
-      }
-    ) @@ DbMigrationAspect.migrate()()
-
-    suite("updated owners contain accurate information")(
-      test("returns true confirming updated owner information") {
-        for {
-          createOwner <- create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
-          _           <- update(createOwner.id, None, None, Some("12 Grimmauld Place, London, England, UK"), None)
-          owner       <- get(createOwner.id)
-        } yield assertTrue(
-          owner.get.firstName == "Harry" && owner.get.address == "12 Grimmauld Place, London, England, UK" && owner.get.address != "4 Privet Drive, Little Whinging, Surrey, UK"
-        )
-      }
-    ) @@ DbMigrationAspect.migrate()()
-
-  }.provideCustomShared(
-    OwnerServiceLive.layer,
-    ZPostgreSQLContainer.Settings.default,
-    ZPostgreSQLContainer.live,
-    TestContainerLayers.dataSourceLayer
-  )
-
+  }
+    .provideCustomShared(
+      OwnerServiceLive.layer,
+      ZPostgreSQLContainer.Settings.default,
+      ZPostgreSQLContainer.live,
+      TestContainerLayers.dataSourceLayer
+    )
 }

--- a/src/test/scala/petclinic/services/OwnerServiceSpec.scala
+++ b/src/test/scala/petclinic/services/OwnerServiceSpec.scala
@@ -22,7 +22,7 @@ object OwnerServiceSpec extends DefaultRunnableSpec {
             createOwner1 <- create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
             createOwner2 <- create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
             owners       <- getAll
-          } yield assertTrue(owners.contains(createOwner1) && owners.contains(createOwner2) && owners.size == 2)
+          } yield assertTrue(owners.contains(createOwner1) && owners.contains(createOwner2))
         }
       ),
       suite("deleted owners do not exist in db")(
@@ -34,7 +34,7 @@ object OwnerServiceSpec extends DefaultRunnableSpec {
             owner <- get(createOwner.id)
           } yield assertTrue(owner.isEmpty)
         },
-        test("returns false confirming non-existence of many deleted owners") {
+        test("returns true confirming non-existence of many deleted owners") {
           for {
             createOwner1 <- create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
             createOwner2 <- create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")

--- a/src/test/scala/petclinic/services/OwnerServiceSpec.scala
+++ b/src/test/scala/petclinic/services/OwnerServiceSpec.scala
@@ -13,46 +13,46 @@ object OwnerServiceSpec extends DefaultRunnableSpec {
       suite("added owners exist in db")(
         test("returns true confirming existence of added owner") {
           for {
-            createOwner <- create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
-            owner       <- get(createOwner.id)
-          } yield assertTrue(owner.get == createOwner)
+            owner    <- create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
+            getOwner <- get(owner.id)
+          } yield assertTrue(getOwner.get == owner)
         },
         test("returns true confirming existence of many added owners") {
           for {
-            createOwner1 <- create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
-            createOwner2 <- create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
-            owners       <- getAll
-          } yield assertTrue(owners.contains(createOwner1) && owners.contains(createOwner2))
+            owner1 <- create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
+            owner2 <- create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
+            owners <- getAll
+          } yield assertTrue(owners.contains(owner1) && owners.contains(owner2))
         }
       ),
       suite("deleted owners do not exist in db")(
         test("returns false confirming non-existence of deleted owner") {
           for {
-            createOwner <-
+            owner <-
               create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
-            _     <- delete(createOwner.id)
-            owner <- get(createOwner.id)
+            _     <- delete(owner.id)
+            owner <- get(owner.id)
           } yield assertTrue(owner.isEmpty)
         },
         test("returns true confirming non-existence of many deleted owners") {
           for {
-            createOwner1 <- create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
-            createOwner2 <- create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
-            createOwner3 <- create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
-            _            <- delete(createOwner1.id)
-            _            <- delete(createOwner2.id)
-            owner1       <- get(createOwner1.id)
-            owner2       <- get(createOwner2.id)
-            owner3       <- get(createOwner3.id)
+            owner1 <- create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
+            owner2 <- create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
+            owner3 <- create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
+            _      <- delete(owner1.id)
+            _      <- delete(owner2.id)
+            owner1 <- get(owner1.id)
+            owner2 <- get(owner2.id)
+            owner3 <- get(owner3.id)
           } yield assertTrue(owner1.isEmpty && owner2.isEmpty && owner3.isDefined)
         }
       ),
       suite("updated owners contain accurate information")(
         test("returns true confirming updated owner information") {
           for {
-            createOwner <- create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
-            _           <- update(createOwner.id, None, None, Some("12 Grimmauld Place, London, England, UK"), None)
-            owner       <- get(createOwner.id)
+            owner <- create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
+            _     <- update(owner.id, None, None, Some("12 Grimmauld Place, London, England, UK"), None)
+            owner <- get(owner.id)
           } yield assertTrue(
             owner.get.firstName == "Harry" && owner.get.address == "12 Grimmauld Place, London, England, UK" && owner.get.address != "4 Privet Drive, Little Whinging, Surrey, UK"
           )

--- a/src/test/scala/petclinic/services/PetServiceSpec.scala
+++ b/src/test/scala/petclinic/services/PetServiceSpec.scala
@@ -14,64 +14,64 @@ object PetServiceSpec extends DefaultRunnableSpec {
       suite("added pets exist in db")(
         test("returns true confirming existence of added pet") {
           for {
-            createOwner <- OwnerService.create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
-            createPet <-
-              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.fromString("Canine"), createOwner.id)
-            pet <- PetService.get(createPet.id)
-          } yield assertTrue(pet.get == createPet)
+            owner <- OwnerService.create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
+            pet <-
+              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.fromString("Canine"), owner.id)
+            getPet <- PetService.get(pet.id)
+          } yield assertTrue(getPet.get == pet)
         },
         test("returns true confirming existence of many added pets") {
           for {
-            createOwner1 <- OwnerService.create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
-            createOwner2 <- OwnerService.create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
-            createPet1 <-
-              PetService.create("Wilbur", LocalDate.of(1952, 10, 15), Species.fromString("Suidae"), createOwner1.id)
-            createPet2 <-
-              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.fromString("Feline"), createOwner2.id)
+            owner1 <- OwnerService.create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
+            owner2 <- OwnerService.create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
+            pet1 <-
+              PetService.create("Wilbur", LocalDate.of(1952, 10, 15), Species.fromString("Suidae"), owner1.id)
+            pet2 <-
+              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.fromString("Feline"), owner2.id)
             pets <- PetService.getAll
-          } yield assertTrue(pets.contains(createPet1) && pets.contains(createPet2))
+          } yield assertTrue(pets.contains(pet1) && pets.contains(pet2))
         }
       ),
       suite("deleted pets do not exist in db")(
         test("returns true confirming non-existence of deleted pet") {
           for {
-            createOwner <-
+            owner <-
               OwnerService.create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
-            createPet <-
-              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.fromString("Canine"), createOwner.id)
-            _   <- PetService.delete(createPet.id)
-            pet <- PetService.get(createPet.id)
-          } yield assertTrue(pet.isEmpty)
+            pet <-
+              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.fromString("Canine"), owner.id)
+            _      <- PetService.delete(pet.id)
+            getPet <- PetService.get(pet.id)
+          } yield assertTrue(getPet.isEmpty)
         },
         test("returns true confirming the non-existence of many deleted pets") {
           for {
-            createOwner1 <- OwnerService.create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
-            createOwner2 <- OwnerService.create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
-            createOwner3 <- OwnerService.create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
-            createPet1 <-
-              PetService.create("Tao", LocalDate.of(1963, 11, 20), Species.fromString("Feline"), createOwner1.id)
-            createPet2 <-
-              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), createOwner2.id)
-            createPet3 <-
-              PetService.create("Luath", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), createOwner3.id)
-            _    <- PetService.delete(createPet1.id)
-            _    <- PetService.delete(createPet2.id)
-            pet1 <- PetService.get(createPet1.id)
-            pet2 <- PetService.get(createPet2.id)
-            pet3 <- PetService.get(createPet3.id)
-          } yield assertTrue(pet1.isEmpty && pet2.isEmpty && pet3.isDefined)
+            owner1 <- OwnerService.create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
+            owner2 <- OwnerService.create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
+            owner3 <- OwnerService.create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
+            pet1 <-
+              PetService.create("Tao", LocalDate.of(1963, 11, 20), Species.fromString("Feline"), owner1.id)
+            pet2 <-
+              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), owner2.id)
+            pet3 <-
+              PetService.create("Luath", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), owner3.id)
+            _       <- PetService.delete(pet1.id)
+            _       <- PetService.delete(pet2.id)
+            getPet1 <- PetService.get(pet1.id)
+            getPet2 <- PetService.get(pet2.id)
+            getPet3 <- PetService.get(pet3.id)
+          } yield assertTrue(getPet1.isEmpty && getPet2.isEmpty && getPet3.isDefined)
         }
       ),
       suite("updated pets contain accurate information")(
         test("returns true confirming updated pet information") {
           for {
-            createOwner <-
+            owner <-
               OwnerService.create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
-            createPet <-
-              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.fromString("Avia"), createOwner.id)
-            _   <- PetService.update(createPet.id, Some("Hedwig"), None, None, None)
-            pet <- PetService.get(createPet.id)
-          } yield assertTrue(pet.get.name == "Hedwig")
+            pet <-
+              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.fromString("Avia"), owner.id)
+            _      <- PetService.update(pet.id, Some("Hedwig"), None, None, None)
+            getPet <- PetService.get(pet.id)
+          } yield assertTrue(getPet.get.name == "Hedwig")
         }
       )
     ) @@ DbMigrationAspect.migrate()()

--- a/src/test/scala/petclinic/services/PetServiceSpec.scala
+++ b/src/test/scala/petclinic/services/PetServiceSpec.scala
@@ -16,7 +16,7 @@ object PetServiceSpec extends DefaultRunnableSpec {
           for {
             owner <- OwnerService.create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
             pet <-
-              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.fromString("Canine"), owner.id)
+              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.Canine, owner.id)
             getPet <- PetService.get(pet.id)
           } yield assertTrue(getPet.get == pet)
         },
@@ -25,9 +25,9 @@ object PetServiceSpec extends DefaultRunnableSpec {
             owner1 <- OwnerService.create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
             owner2 <- OwnerService.create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
             pet1 <-
-              PetService.create("Wilbur", LocalDate.of(1952, 10, 15), Species.fromString("Suidae"), owner1.id)
+              PetService.create("Wilbur", LocalDate.of(1952, 10, 15), Species.Suidae, owner1.id)
             pet2 <-
-              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.fromString("Feline"), owner2.id)
+              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.Feline, owner2.id)
             pets <- PetService.getAll
           } yield assertTrue(pets.contains(pet1) && pets.contains(pet2))
         }
@@ -38,7 +38,7 @@ object PetServiceSpec extends DefaultRunnableSpec {
             owner <-
               OwnerService.create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
             pet <-
-              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.fromString("Canine"), owner.id)
+              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.Canine, owner.id)
             _      <- PetService.delete(pet.id)
             getPet <- PetService.get(pet.id)
           } yield assertTrue(getPet.isEmpty)
@@ -49,11 +49,11 @@ object PetServiceSpec extends DefaultRunnableSpec {
             owner2 <- OwnerService.create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
             owner3 <- OwnerService.create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
             pet1 <-
-              PetService.create("Tao", LocalDate.of(1963, 11, 20), Species.fromString("Feline"), owner1.id)
+              PetService.create("Tao", LocalDate.of(1963, 11, 20), Species.Feline, owner1.id)
             pet2 <-
-              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), owner2.id)
+              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.Canine, owner2.id)
             pet3 <-
-              PetService.create("Luath", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), owner3.id)
+              PetService.create("Luath", LocalDate.of(1963, 11, 20), Species.Canine, owner3.id)
             _       <- PetService.delete(pet1.id)
             _       <- PetService.delete(pet2.id)
             getPet1 <- PetService.get(pet1.id)
@@ -68,7 +68,7 @@ object PetServiceSpec extends DefaultRunnableSpec {
             owner <-
               OwnerService.create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
             pet <-
-              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.fromString("Avia"), owner.id)
+              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.Avia, owner.id)
             _      <- PetService.update(pet.id, Some("Hedwig"), None, None, None)
             getPet <- PetService.get(pet.id)
           } yield assertTrue(getPet.get.name == "Hedwig")

--- a/src/test/scala/petclinic/services/PetServiceSpec.scala
+++ b/src/test/scala/petclinic/services/PetServiceSpec.scala
@@ -1,3 +1,86 @@
-package petclinic.services object PetServiceSpec {
+package petclinic.services
+
+import io.github.scottweaver.zio.aspect.DbMigrationAspect
+import io.github.scottweaver.zio.testcontainers.postgres.ZPostgreSQLContainer
+import petclinic.models.Species
+import zio.test._
+
+import java.time.LocalDate
+
+object PetServiceSpec extends DefaultRunnableSpec {
+
+  override def spec: Spec[TestEnvironment, TestFailure[Throwable], TestSuccess] = {
+    suite("PetService")(
+      suite("added pets exist in db")(
+        test("returns true confirming existence of added pet") {
+          for {
+            createOwner <- OwnerService.create("Emily", "Elizabeth", "1 Birdwell Island, New York, NY", "212-215-1928")
+            createPet <-
+              PetService.create("Clifford", LocalDate.of(1962, 2, 14), Species.fromString("Canine"), createOwner.id)
+            pet <- PetService.get(createPet.id)
+          } yield assertTrue(pet.get == createPet)
+        },
+        test("returns true confirming existence of many added pets") {
+          for {
+            createOwner1 <- OwnerService.create("Fern", "Arable", "Arable Farm, Brooklin, ME", "207-711-1899")
+            createOwner2 <- OwnerService.create("Jon", "Arbuckle", "711 Maple St, Muncie, IN", "812-728-1945")
+            createPet1 <-
+              PetService.create("Wilbur", LocalDate.of(1952, 10, 15), Species.fromString("Suidae"), createOwner1.id)
+            createPet2 <-
+              PetService.create("Garfield", LocalDate.of(1978, 6, 19), Species.fromString("Feline"), createOwner2.id)
+            pets <- PetService.getAll
+          } yield assertTrue(pets.contains(createPet1) && pets.contains(createPet2))
+        }
+      ),
+      suite("deleted pets do not exist in db")(
+        test("returns true confirming non-existence of deleted pet") {
+          for {
+            createOwner <-
+              OwnerService.create("Sherlock", "Holmes", "221B Baker St, London, England, UK", "+44-20-7224-3688")
+            createPet <-
+              PetService.create("Toby", LocalDate.of(1888, 4, 17), Species.fromString("Canine"), createOwner.id)
+            _   <- PetService.delete(createPet.id)
+            pet <- PetService.get(createPet.id)
+          } yield assertTrue(pet.isEmpty)
+        },
+        test("returns true confirming the non-existence of many deleted pets") {
+          for {
+            createOwner1 <- OwnerService.create("Elizabeth", "Hunter", "Ontario, Canada", "807-511-1918")
+            createOwner2 <- OwnerService.create("Peter", "Hunter", "Ontario, Canada", "807-511-1918")
+            createOwner3 <- OwnerService.create("Jim", "Hunter", "Ontario, Canada", "807-511-1918")
+            createPet1 <-
+              PetService.create("Tao", LocalDate.of(1963, 11, 20), Species.fromString("Feline"), createOwner1.id)
+            createPet2 <-
+              PetService.create("Bodger", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), createOwner2.id)
+            createPet3 <-
+              PetService.create("Luath", LocalDate.of(1963, 11, 20), Species.fromString("Canine"), createOwner3.id)
+            _    <- PetService.delete(createPet1.id)
+            _    <- PetService.delete(createPet2.id)
+            pet1 <- PetService.get(createPet1.id)
+            pet2 <- PetService.get(createPet2.id)
+            pet3 <- PetService.get(createPet3.id)
+          } yield assertTrue(pet1.isEmpty && pet2.isEmpty && pet3.isDefined)
+        }
+      ),
+      suite("updated pets contain accurate information")(
+        test("returns true confirming updated pet information") {
+          for {
+            createOwner <-
+              OwnerService.create("Harry", "Potter", "4 Privet Drive, Little Whinging, Surrey, UK", "+44-20-7224-3688")
+            createPet <-
+              PetService.create("Snowy Owl", LocalDate.of(1991, 1, 1), Species.fromString("Avia"), createOwner.id)
+            _   <- PetService.update(createPet.id, Some("Hedwig"), None, None, None)
+            pet <- PetService.get(createPet.id)
+          } yield assertTrue(pet.get.name == "Hedwig")
+        }
+      )
+    ) @@ DbMigrationAspect.migrate()()
+  }.provideCustomShared(
+    PetServiceLive.layer,
+    OwnerServiceLive.layer,
+    ZPostgreSQLContainer.Settings.default,
+    ZPostgreSQLContainer.live,
+    TestContainerLayers.dataSourceLayer
+  )
 
 }

--- a/src/test/scala/petclinic/services/PetServiceSpec.scala
+++ b/src/test/scala/petclinic/services/PetServiceSpec.scala
@@ -1,0 +1,3 @@
+package petclinic.services object PetServiceSpec {
+
+}

--- a/src/test/scala/petclinic/services/TestContainerLayers.scala
+++ b/src/test/scala/petclinic/services/TestContainerLayers.scala
@@ -1,0 +1,32 @@
+package petclinic.services
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import io.github.scottweaver.models.JdbcInfo
+import zio.{ZIO, ZLayer}
+
+import java.util.Properties
+import javax.sql.DataSource
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+object TestContainerLayers {
+
+  val dataSourceLayer: ZLayer[JdbcInfo, Nothing, DataSource] = ZLayer {
+    for {
+      jdbcInfo   <- ZIO.service[JdbcInfo]
+      datasource <- ZIO.attemptBlocking(unsafeDataSourceFromJdbcInfo(jdbcInfo)).orDie
+    } yield datasource
+  }
+
+  private def unsafeDataSourceFromJdbcInfo(jdbcInfo: JdbcInfo): DataSource = {
+    val props = new Properties()
+    props.putAll(
+      Map(
+        "driverClassName" -> jdbcInfo.driverClassName,
+        "jdbcUrl"         -> jdbcInfo.jdbcUrl,
+        "username"        -> jdbcInfo.username,
+        "password"        -> jdbcInfo.password
+      ).asJava
+    )
+    new HikariDataSource(new HikariConfig(props))
+  }
+}


### PR DESCRIPTION
Addresses #33

In addition to creating some basic tests for AppointmentService, I created a Vet service with a getAll method, updated the create method on Appointment to randomly assign to it a VetId (removed VetId as a param of create), and fixed a formatting error in the migration.

*Note: In regard to the structure of appointment creation, I may, in the future, explore caching the result of getting all of the vets, rather than getting them every time an appointment is created.